### PR TITLE
Fix Avo admin 500s: add missing resource controllers

### DIFF
--- a/app/controllers/avo/campaigns_controller.rb
+++ b/app/controllers/avo/campaigns_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/3.0/controllers.html
+class Avo::CampaignsController < Avo::ResourcesController
+end

--- a/app/controllers/avo/companies_controller.rb
+++ b/app/controllers/avo/companies_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/3.0/controllers.html
+class Avo::CompaniesController < Avo::ResourcesController
+end

--- a/app/controllers/avo/deliveries_controller.rb
+++ b/app/controllers/avo/deliveries_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/3.0/controllers.html
+class Avo::DeliveriesController < Avo::ResourcesController
+end

--- a/app/controllers/avo/email_templates_controller.rb
+++ b/app/controllers/avo/email_templates_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/3.0/controllers.html
+class Avo::EmailTemplatesController < Avo::ResourcesController
+end

--- a/app/controllers/avo/segments_controller.rb
+++ b/app/controllers/avo/segments_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/3.0/controllers.html
+class Avo::SegmentsController < Avo::ResourcesController
+end

--- a/app/controllers/avo/subscribers_controller.rb
+++ b/app/controllers/avo/subscribers_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/3.0/controllers.html
+class Avo::SubscribersController < Avo::ResourcesController
+end

--- a/app/controllers/avo/suppressions_controller.rb
+++ b/app/controllers/avo/suppressions_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/3.0/controllers.html
+class Avo::SuppressionsController < Avo::ResourcesController
+end

--- a/app/controllers/avo/team_ses_configurations_controller.rb
+++ b/app/controllers/avo/team_ses_configurations_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/3.0/controllers.html
+class Avo::TeamSesConfigurationsController < Avo::ResourcesController
+end

--- a/app/controllers/avo/team_ses_domains_controller.rb
+++ b/app/controllers/avo/team_ses_domains_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/3.0/controllers.html
+class Avo::TeamSesDomainsController < Avo::ResourcesController
+end

--- a/test/integration/avo_admin_access_test.rb
+++ b/test/integration/avo_admin_access_test.rb
@@ -67,6 +67,33 @@ class AvoAdminAccessTest < ActionDispatch::IntegrationTest
       "Admin should reach the Users resource index, got #{response.status}"
   end
 
+  # Avo's dynamic router draws `resources <route_key>` for every registered
+  # resource (see config/routes/dynamic_routes.rb in the avo gem), and each of
+  # those routes points at an `Avo::<Plural>Controller` that we have to supply
+  # ourselves in app/controllers/avo/. If a resource is added without its
+  # matching controller, the route 500s at request time with
+  # `uninitialized constant Avo::<Plural>Controller` — which is exactly how
+  # /admin/avo/resources/suppressions and .../deliveries blew up in production.
+  # This guards every resource index at once so a missing controller is caught
+  # in CI instead of Sentry.
+  test "every Avo resource index renders for an admin" do
+    user = create(:onboarded_user)
+    ENV["DEVELOPER_EMAILS"] = user.email
+    assert user.reload.developer?, "user should match the DEVELOPER_EMAILS allowlist"
+
+    sign_in user
+
+    resources = Avo::Resources::ResourceManager.fetch_resources
+    assert resources.any?, "expected Avo to have registered resources"
+
+    resources.each do |resource|
+      get "/admin/avo/resources/#{resource.route_key}"
+      assert_response :success,
+        "Admin should reach the #{resource.route_key} resource index " \
+        "(needs Avo::#{resource.route_key.camelize}Controller), got #{response.status}"
+    end
+  end
+
   test "an unauthenticated visitor cannot reach /admin/avo" do
     ENV["DEVELOPER_EMAILS"] = "anyone@example.com"
     get "/admin/avo"


### PR DESCRIPTION
## Problem

Production Sentry issue [LEWNETTER-D](https://lewsnetter.sentry.io/issues/7512257476/): visiting `/admin/avo/resources/suppressions` and `/admin/avo/resources/deliveries` returns a 500 with:

```
ActionDispatch::MissingController: uninitialized constant Avo::SuppressionsController
```

## Root cause

Avo's dynamic router (`config/routes/dynamic_routes.rb` in the `avo` gem) draws `resources <route_key>` for **every** registered resource, and each route points at an `Avo::<Plural>Controller` that the host app must supply in `app/controllers/avo/`. Avo does not auto-define these.

Only 5 of the 14 Avo resources had a controller file. The other 9 — `campaign`, `company`, `delivery`, `email_template`, `segment`, `subscriber`, `suppression`, `team_ses_configuration`, `team_ses_domain` — had none, so hitting their index page raised `uninitialized constant` at request time. Sentry only surfaced the two resources an admin happened to click.

## Fix

- Add the 9 missing `Avo::<Plural>Controller` classes, each subclassing `Avo::ResourcesController` (matching the existing generated boilerplate). All 14 resources now have controllers.
- Extend `test/integration/avo_admin_access_test.rb` with a test that iterates over `Avo::Resources::ResourceManager.fetch_resources` and GETs every resource index as an admin, asserting `:success`. A resource added later without its controller will now fail in CI instead of Sentry.

## Verification

```
bin/rails test test/integration/avo_admin_access_test.rb
4 tests, 23 assertions, 0 failures, 0 errors, 0 skips
```

The new `test_every_Avo_resource_index_renders_for_an_admin` exercises all 14 resources, including the two that were 500ing in production.

Fixes LEWNETTER-D

🤖 Generated with [Claude Code](https://claude.com/claude-code)