### PR TITLE
Make Cloudflare R2 optional with graceful fallback to local volume

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,11 @@
 #   SSH_PRIVATE_KEY                     deploy key for Kamal SSH
 #   SERVER_HOST                         the production server IP/hostname
 #   RAILS_MASTER_KEY                    decrypts config/credentials.yml.enc
+#
+# Optional repo secrets — only needed if you enable Cloudflare R2 backup
+# (see config/deploy.yml's LITESTREAM_REPLICA_BUCKET). Leave them unset for a
+# volume-only deploy; the step below writes empty values and litestream stays
+# dormant:
 #   LITESTREAM_REPLICA_ACCESS_KEY_ID    Cloudflare R2 access key
 #   LITESTREAM_REPLICA_SECRET_ACCESS_KEY  Cloudflare R2 secret
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The MCP server exposes 43 tools spanning subscribers, segments, email templates,
 ## Stack
 
 - **Rails 8.1** on Ruby 4
-- **SQLite** primary + queue + Cable, [Litestream](https://litestream.io) → Cloudflare R2 backup
+- **SQLite** primary + queue + Cable, with optional [Litestream](https://litestream.io) → Cloudflare R2 backup (opt-in; defaults to volume-only)
 - **[BulletTrain](https://bullettrain.co)** for teams, Devise auth, CanCanCan, billing scaffolding
 - **AWS SES v2** (`aws-sdk-sesv2`) for sending; per-team credentials
 - **MJML** for responsive email templates; **Liquid** for body interpolation

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -2,15 +2,25 @@
 
 # Lewsnetter production entrypoint.
 #
-# Responsibilities:
-#   1. Restore each SQLite database from R2 if the local file is missing
-#      (litestream-restore is a no-op when no replica or no local file exists).
-#   2. Run db:prepare on first boot so a fresh server has schema + seeds.
-#   3. If the command is `bin/rails server`, wrap it in `litestream replicate
-#      -exec` so the replicator runs alongside Puma and dies with it.
-#      Otherwise (e.g. worker role running `bin/rake solid_queue:start`),
-#      just exec the command directly — the web role's replicate covers all
-#      three databases.
+# R2 / Litestream backup is OPTIONAL. We detect "R2 enabled" by the presence
+# of $LITESTREAM_REPLICA_BUCKET (set in config/deploy.yml's env.clear when the
+# operator opts into Cloudflare R2 / any S3-compatible backup target).
+#
+#   R2 ENABLED  ($LITESTREAM_REPLICA_BUCKET set):
+#     1. Restore each SQLite database from R2 if the local file is missing
+#        (litestream-restore is a no-op when no replica or no local file exists).
+#     2. If the command is `bin/rails server`, wrap it in `litestream replicate
+#        -exec` so the replicator runs alongside Puma and dies with it.
+#        Otherwise (e.g. worker role running `bin/rake solid_queue:start`),
+#        exec directly — the web role's replicate covers all three databases.
+#
+#   R2 DISABLED ($LITESTREAM_REPLICA_BUCKET unset — the default):
+#     Skip restore and the replicate wrap entirely; exec the command directly.
+#     SQLite lives on the /rails/storage named volume and survives redeploys,
+#     so the box is durable as long as the volume is. No Cloudflare account
+#     required — this is the zero-setup path for OSS self-hosters.
+#
+# Either way, db:prepare + first-boot model seeding run unconditionally.
 
 # Enable jemalloc for reduced memory usage and latency.
 if [ -z "${LD_PRELOAD+x}" ]; then
@@ -26,10 +36,13 @@ restore_if_missing() {
   fi
 }
 
-# Restore each of the three SQLite databases if local file doesn't exist.
-restore_if_missing /rails/storage/lewsnetter_production.sqlite3
-restore_if_missing /rails/storage/lewsnetter_production_queue.sqlite3
-restore_if_missing /rails/storage/lewsnetter_production_cable.sqlite3
+# Restore each of the three SQLite databases from R2 if the local file is
+# missing — only when R2 backup is enabled.
+if [ -n "$LITESTREAM_REPLICA_BUCKET" ]; then
+  restore_if_missing /rails/storage/lewsnetter_production.sqlite3
+  restore_if_missing /rails/storage/lewsnetter_production_queue.sqlite3
+  restore_if_missing /rails/storage/lewsnetter_production_cable.sqlite3
+fi
 
 # Prepare DBs on first boot (idempotent — does nothing if schema already
 # loaded). Only run if we're about to start the Rails server; workers should
@@ -47,9 +60,10 @@ if [ "${1}" = "./bin/rails" ] && [ "${2}" = "server" ]; then
   ./bin/rails subscribers:encrypt_at_rest
 fi
 
-# Web role: wrap the server in litestream replicate so the replicator
-# streams writes to R2. Worker role: exec directly.
-if [ "${1}" = "./bin/rails" ] && [ "${2}" = "server" ]; then
+# Web role with R2 enabled: wrap the server in litestream replicate so the
+# replicator streams writes to R2. Otherwise (R2 disabled, or the worker
+# role) exec the command directly.
+if [ -n "$LITESTREAM_REPLICA_BUCKET" ] && [ "${1}" = "./bin/rails" ] && [ "${2}" = "server" ]; then
   exec litestream replicate -config /etc/litestream.yml -exec "$*"
 else
   exec "$@"

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -118,11 +118,26 @@ env:
     LEWSNETTER_ABUSE_EMAIL: "abuse@lewsnetter.dev"
     HIDE_THINGS: "true"
     HIDE_EXAMPLES: "true"
-    # Litestream → Cloudflare R2. Bucket `lewsnetter-litestream` was
-    # provisioned in CF account 407493dfba8306ff79bb5cd68f609eb0 (ENAM).
+    # ── OPTIONAL: Cloudflare R2 backup (Litestream) ───────────────────────
+    # R2 is OPT-IN. Setting LITESTREAM_REPLICA_BUCKET is the single switch
+    # that turns on R2 for both Litestream DB backups AND Active Storage
+    # uploads — bin/docker-entrypoint gates the litestream restore/replicate
+    # on this var, and config/environments/production.rb routes Active Storage
+    # to R2 when it's present (else to the /rails/storage volume).
+    #
+    # For a MINIMAL, volume-only deploy (no Cloudflare account needed),
+    # DELETE these three lines — SQLite + uploads then live entirely on the
+    # persistent lewsnetter_storage volume and survive redeploys.
+    #
+    # The matching R2 credentials live in env.secret below; with R2 enabled
+    # they must also be set in .kamal/secrets.
+    #
+    # Bucket `lewsnetter-litestream` was provisioned in CF account
+    # 407493dfba8306ff79bb5cd68f609eb0 (ENAM) for the hosted deployment.
     LITESTREAM_REPLICA_BUCKET: lewsnetter-litestream
     LITESTREAM_REPLICA_ENDPOINT: https://407493dfba8306ff79bb5cd68f609eb0.r2.cloudflarestorage.com
     LITESTREAM_REPLICA_REGION: auto
+    # ──────────────────────────────────────────────────────────────────────
     # Stripe price IDs aren't sensitive (they're public refs to your
     # pricing config). The secret keys live in env.secret below.
     STRIPE_PRODUCT_PRO_MONTHLY_2026_PRICE_ID: price_1TYDKzJJh96TtdCTaNDgbtqa
@@ -138,13 +153,26 @@ env:
     # abilities. Self-hosters: override this with your own admin emails.
     DEVELOPER_EMAILS: "bruno@influencekit.com"
   secret:
+    # Required for any deploy.
     - RAILS_MASTER_KEY
-    - LITESTREAM_REPLICA_ACCESS_KEY_ID
-    - LITESTREAM_REPLICA_SECRET_ACCESS_KEY
     - STRIPE_PUBLISHABLE_KEY
     - STRIPE_SECRET_KEY
     - STRIPE_WEBHOOKS_ENDPOINT_SECRET
     - SENTRY_DSN
+    # OPTIONAL: Cloudflare R2 backup credentials (paired with the
+    # LITESTREAM_REPLICA_* block in env.clear above). These are listed so the
+    # hosted deployment injects them, but they are NOT mandatory — for a
+    # volume-only deploy leave them EMPTY in .kamal/secrets:
+    #
+    #   LITESTREAM_REPLICA_ACCESS_KEY_ID=
+    #   LITESTREAM_REPLICA_SECRET_ACCESS_KEY=
+    #
+    # Kamal injects the empty values, litestream is never invoked (the
+    # entrypoint gates on LITESTREAM_REPLICA_BUCKET), and nothing breaks.
+    # An empty value is fine; a key MISSING from .kamal/secrets makes Kamal
+    # error — so keep the lines, just blank, on the no-R2 path.
+    - LITESTREAM_REPLICA_ACCESS_KEY_ID
+    - LITESTREAM_REPLICA_SECRET_ACCESS_KEY
     # Note: ORIGIN_CERT / ORIGIN_KEY are NOT exposed to the app containers.
     # They're consumed by the proxy block above via Kamal's native
     # `proxy.ssl.{certificate_pem,private_key_pem}` mechanism, which reads

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,8 +21,8 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 
-  # Store uploaded files on Cloudflare R2 (S3-compatible). See config/storage.yml.
-  config.active_storage.service = :amazon
+  # Active Storage service is wired below (search "r2_configured?"). It uses
+  # Cloudflare R2 when R2 is configured, else the local /rails/storage volume.
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   config.assume_ssl = true
@@ -101,11 +101,20 @@ Rails.application.configure do
   # part of the Postgres → SQLite swap so background jobs run on the same
   # SQLite-backed queue database.
 
-  # Active Storage is wired to Cloudflare R2 via the `:amazon` service in
-  # config/storage.yml (credentials live in cloudflare.r2_uploads). The legacy
-  # AWS / Bucketeer / Cloudinary env-var sniffing has been replaced because
-  # without it production silently falls back to local disk.
-  config.active_storage.service = :amazon
+  # Active Storage: Cloudflare R2 is OPTIONAL. Use the R2 `:amazon` service
+  # (config/storage.yml, credentials in cloudflare.r2_uploads) when R2 is
+  # configured; otherwise fall back to `:local` Disk pointed at the persistent
+  # /rails/storage volume. This lets an OSS self-hoster deploy with zero
+  # Cloudflare/R2 setup — uploads just live on the same volume as the SQLite
+  # databases and survive redeploys.
+  #
+  # "R2 configured" = R2 upload credentials present, OR the Litestream backup
+  # env is set (an operator who turned on R2 for backups almost certainly
+  # wants it for uploads too). Power users set either and keep full R2.
+  r2_configured =
+    Rails.application.credentials.dig(:cloudflare, :r2_uploads, :access_key_id).present? ||
+    ENV["LITESTREAM_REPLICA_BUCKET"].present?
+  config.active_storage.service = r2_configured ? :amazon : :local
 
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -34,6 +34,17 @@ amazon:
 # In test + dev the service is local Disk — EmailImage#file hardcodes
 # `service: :email_media`, so without this branch every test that attaches
 # a file would try to hit the real R2 bucket and fail with NoSuchBucket.
+#
+# In production, R2 is OPTIONAL: use the dedicated R2 bucket when R2 upload
+# credentials are present, otherwise fall back to local Disk on the persistent
+# /rails/storage volume. Email images reach inboxes via the /e/:id Rails
+# redirect (EmailImage#public_url) regardless of backing store, so the local
+# Disk path works fine for a zero-R2 self-hosted deploy.
+<%
+  r2_configured =
+    Rails.application.credentials.dig(:cloudflare, :r2_uploads, :access_key_id).present? ||
+    ENV["LITESTREAM_REPLICA_BUCKET"].present?
+%>
 <% if Rails.env.test? %>
 email_media:
   service: Disk
@@ -42,7 +53,7 @@ email_media:
 email_media:
   service: Disk
   root: <%= Rails.root.join("storage_email_media") %>
-<% else %>
+<% elsif r2_configured %>
 email_media:
   service: S3
   access_key_id: <%= Rails.application.credentials.dig(:cloudflare, :r2_uploads, :access_key_id) %>
@@ -53,6 +64,10 @@ email_media:
   force_path_style: true
   request_checksum_calculation: when_required
   response_checksum_validation: when_required
+<% else %>
+email_media:
+  service: Disk
+  root: <%= Rails.root.join("storage", "email_media") %>
 <% end %>
 
 cloudinary:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ The "why we built it this way" doc. For evaluators, contributors, and future-Bru
 |---|---|---|
 | Framework | Rails 8.1 + [BulletTrain](https://bullettrain.co) 1.45 | Boring, fast, the team-multitenancy + admin scaffolding from BT is worth more than a custom framework. |
 | Database | SQLite | One file per database, fast, no separate process to operate. Modern SQLite handles way more concurrent writers than the 2010-era takes suggest. |
-| Backup | [Litestream](https://litestream.io) → Cloudflare R2 | Streams every WAL frame to R2 within seconds. Point-in-time restore. R2 has no egress fees. |
+| Backup | _Optional_ [Litestream](https://litestream.io) → Cloudflare R2 | Opt-in (set `LITESTREAM_REPLICA_BUCKET`): streams every WAL frame to R2 within seconds for point-in-time restore. R2 has no egress fees. Off by default — SQLite + uploads then live on the persistent volume only. See [self-hosting](self-hosting.md). |
 | Background jobs | Solid Queue (Rails 8 built-in) | Lives in SQLite, no Redis dependency. |
 | WebSockets | Solid Cable | Same logic — no Redis. |
 | Deploy | [Kamal 2](https://kamal-deploy.org) + kamal-proxy | One-box Docker with rolling deploys + TLS termination at the proxy. |

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -39,7 +39,11 @@ OK, you're self-hosting. Here's the walkthrough.
             └─────────────────────────┘
 ```
 
-Two container roles off one image: `web` and `worker`. SQLite on a Docker named volume. Litestream streams the DB files to Cloudflare R2 (or any S3-compatible target) so you can recover from a server loss.
+Two container roles off one image: `web` and `worker`. SQLite on a Docker named volume.
+
+**Cloudflare R2 is optional.** Out of the box (no R2 setup), SQLite databases and Active Storage uploads live entirely on the persistent `lewsnetter_storage` volume and survive redeploys — zero Cloudflare account required. If you opt in, Litestream streams the DB files to Cloudflare R2 (or any S3-compatible target) so you can recover from a total server loss, and uploads move to R2 too. Opt in by setting `LITESTREAM_REPLICA_BUCKET` (+ credentials) — see the two paths in Step 4.
+
+> The R2 backup path in the diagram above (the Litestream → R2 arrow) only exists when you enable it. The volume-only default stops at the SQLite-on-disk box.
 
 ## Prerequisites
 
@@ -49,7 +53,7 @@ Two container roles off one image: `web` and `worker`. SQLite on a Docker named 
 | **Domain** | Anything you control | You'll point it at the server's IP. |
 | **Cloudflare** | Free account | Used as proxy + Origin CA cert authority. |
 | **GHCR or Docker registry** | GitHub Container Registry works | Kamal pushes images here. |
-| **Backup target** | Cloudflare R2 (recommended) | Litestream supports S3, GCS, ABS, SFTP too. |
+| **Backup target** | _Optional_ — Cloudflare R2 or any S3-compatible bucket | Off-box DB backup via Litestream. Skip it and your data lives on the volume only (fine for low-stakes deploys; back the volume up yourself). |
 | **AWS** | An SES account | The product needs this to send. |
 
 ## Step 1: Provision the server + DNS
@@ -78,15 +82,20 @@ Or fork on GitHub and clone your fork — you'll probably want to commit your ow
 
 ## Step 4: Create `.kamal/secrets`
 
-The file format + every required variable is documented in [`config/deploy.yml`](../config/deploy.yml). Quick start:
+The file format + every required variable is documented in [`config/deploy.yml`](../config/deploy.yml). There are two paths — pick one.
+
+### Path A — Minimal (no R2, volume-only) — the default
+
+No Cloudflare R2 account needed. SQLite + uploads live on the persistent volume. Note the two `LITESTREAM_REPLICA_*` lines are still present but **left empty** — Kamal errors on a secret that's *missing* from this file, but an empty value is fine and keeps litestream dormant.
 
 ```sh
 cat > .kamal/secrets <<'EOF'
 KAMAL_REGISTRY_PASSWORD=$(gh auth token)
 RAILS_MASTER_KEY=$(cat config/master.key)
 
-LITESTREAM_REPLICA_ACCESS_KEY_ID=<r2-access-key>
-LITESTREAM_REPLICA_SECRET_ACCESS_KEY=<r2-secret-key>
+# Cloudflare R2 backup is OFF — leave these empty (don't delete the lines).
+LITESTREAM_REPLICA_ACCESS_KEY_ID=
+LITESTREAM_REPLICA_SECRET_ACCESS_KEY=
 
 STRIPE_PUBLISHABLE_KEY=<your-stripe-pk>      # only if you enable billing
 STRIPE_SECRET_KEY=<your-stripe-sk>
@@ -103,6 +112,19 @@ EOF
 chmod 600 .kamal/secrets
 ```
 
+Then in Step 5, **delete the `env.clear.LITESTREAM_REPLICA_*` block** from `config/deploy.yml`. With `LITESTREAM_REPLICA_BUCKET` unset, the entrypoint skips litestream entirely and Active Storage uses the local volume.
+
+### Path B — With R2 backup (optional)
+
+Same as Path A, but fill in real R2 credentials and keep the `LITESTREAM_REPLICA_*` block in `config/deploy.yml`:
+
+```sh
+LITESTREAM_REPLICA_ACCESS_KEY_ID=<r2-access-key>
+LITESTREAM_REPLICA_SECRET_ACCESS_KEY=<r2-secret-key>
+```
+
+You'll also need to point `config/deploy.yml`'s `env.clear.LITESTREAM_REPLICA_BUCKET` / `_ENDPOINT` / `_REGION` at your own bucket, and (for Active Storage uploads on R2) add `cloudflare.r2_uploads.*` to your encrypted credentials (`bin/rails credentials:edit`). See `config/storage.yml`.
+
 ## Step 5: Edit `config/deploy.yml`
 
 The shipped config is for the hosted Lewsnetter deployment. You'll want to change:
@@ -113,7 +135,7 @@ The shipped config is for the hosted Lewsnetter deployment. You'll want to chang
 - `env.clear.MARKETING_BASE_URL` → drop it unless you split marketing + app onto two hosts; single-host deployments leave it unset
 - `env.clear.BRANDED_HOST_CNAME_TARGET` → drop it unless tenants brand their unsubscribe/tracking subdomains; if you keep it, point it at a DNS-only host that resolves straight to your origin. Unset, it falls back to the `BASE_URL` host
 - `env.clear.LEWSNETTER_LEGAL_EMAIL` + `LEWSNETTER_ABUSE_EMAIL` → real mailboxes you check
-- `env.clear.LITESTREAM_REPLICA_*` → your R2 / S3 bucket details
+- `env.clear.LITESTREAM_REPLICA_*` → **Path A (no R2):** delete this block. **Path B (R2):** point it at your R2 / S3 bucket details
 - `registry.username` → your GHCR (or other) username
 
 ## Step 6: Deploy
@@ -137,7 +159,7 @@ There's a workflow at [`.github/workflows/deploy.yml`](../.github/workflows/depl
 - `SERVER_HOST` — server IP
 - `RAILS_MASTER_KEY`
 - `ORIGIN_CERT` + `ORIGIN_KEY`
-- `LITESTREAM_REPLICA_ACCESS_KEY_ID` + `_SECRET_ACCESS_KEY`
+- `LITESTREAM_REPLICA_ACCESS_KEY_ID` + `_SECRET_ACCESS_KEY` — **optional** (Path B only); leave unset for a volume-only deploy and the workflow writes empty values
 - `STRIPE_PUBLISHABLE_KEY` + `_SECRET_KEY` + `_WEBHOOKS_ENDPOINT_SECRET` (only if you enable billing)
 
 Add those, push to master, and CI redeploys on every commit.
@@ -158,7 +180,9 @@ The hosted Lewsnetter splits `lewsnetter.dev` (marketing) and `app.lewsnetter.de
 
 ## Backups + restore
 
-Litestream streams every SQLite write to R2 within seconds. To restore:
+**Path A (no R2):** your data lives only on the `lewsnetter_storage` volume. It survives container restarts and redeploys, but NOT a server loss. Back it up yourself — e.g. a cron'd `sqlite3 .backup` of `/rails/storage/*.sqlite3` to off-box storage, or snapshot the Docker volume. If you outgrow this, switch to Path B.
+
+**Path B (R2):** Litestream streams every SQLite write to R2 within seconds. To restore:
 
 ```sh
 litestream restore -config /etc/litestream.yml /rails/storage/lewsnetter_production.sqlite3


### PR DESCRIPTION
## Why

Today lewsnetter **hard-requires** Cloudflare R2: `bin/docker-entrypoint` runs `litestream replicate -exec` unconditionally for the web role, and production Active Storage hard-points at the R2 S3 service. That forces every OSS self-hoster to create a Cloudflare account + R2 buckets + token just to deploy.

This makes R2 (Litestream DB backup **and** Active Storage uploads) **opt-in**, with graceful fallback to the persistent `/rails/storage` volume.

**Rule:** use R2 if enabled, else use the volume. "Enabled" is detected by presence of `LITESTREAM_REPLICA_BUCKET` (env) or `credentials.cloudflare.r2_uploads.*`. Works with them ABSENT (new default) and PRESENT (current hosted behavior — unchanged).

## Changes

1. **`bin/docker-entrypoint`** — gate restore + the `litestream replicate -exec` wrap on `[ -n "$LITESTREAM_REPLICA_BUCKET" ]`. Unset → skip both, `exec "$@"` directly. SQLite lives on the volume and survives redeploys. `db:prepare` + first-boot model seeding stay unconditional.
2. **`config/environments/production.rb`** — `config.active_storage.service` is `:amazon` (R2) when configured, else `:local` Disk on the `/rails/storage` volume, via an `r2_configured` predicate. (Also removed the duplicate unconditional `= :amazon` assignment.)
3. **`config/storage.yml`** — the production `email_media` service falls back to local Disk when R2 isn't configured (`EmailImage#file` pins `service: :email_media`, so it can't be left hard-S3). Images still reach inboxes via the `/e/:id` redirect regardless of backing store.
4. **`config/deploy.yml`** — clearly mark the R2 `env.clear` block and the two `LITESTREAM_REPLICA_*` `env.secret` entries as optional. They tolerate empty values in `.kamal/secrets`, so `kamal deploy` succeeds with R2 unset. Minimal required secrets = `RAILS_MASTER_KEY` + app keys + `KAMAL_REGISTRY_PASSWORD`.
5. **`.github/workflows/deploy.yml`** — document the R2 GitHub secrets as optional (the `printf` step already writes empty values when they're unset, so CI is already tolerant).
6. **docs** — `self-hosting.md` now documents both **Path A: minimal (no R2, volume-only)** default and **Path B: with R2 backup (optional)**; README + architecture.md note R2 is opt-in.

> **Note:** TLS via the Cloudflare Origin cert is separate from R2 — the proxy / Origin-cert setup is left as-is.

## Verification

- ✅ Scoped test suite green — `test/services test/jobs test/controllers/account` + `email_image_test`: **298 tests, 0 failures, 0 errors, 2 skips** (after the standard `assets:precompile` CI prerequisite).
- ✅ `kamal config` validates with R2 secrets unset (exit 0).
- ✅ Entrypoint dry-run (stubbed `litestream`/`rails`): with `LITESTREAM_REPLICA_BUCKET` **unset** → no litestream calls, `db:prepare` + seeds run, direct exec; **set** → restore ×3, `db:prepare` + seeds, then `litestream replicate -exec` wrap.
- ✅ `storage.yml` renders `email_media` → Disk when R2 unset, S3 when set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)