### PR TITLE
Sync companies inline from the subscriber bulk payload

### DIFF
--- a/app/controllers/api/v1/subscribers_controller.rb
+++ b/app/controllers/api/v1/subscribers_controller.rb
@@ -77,11 +77,15 @@ if defined?(Api::V1::ApplicationController)
           row[:custom_attributes] = row.delete(:attributes) if row.key?(:attributes)
           row[:custom_attributes] = ::Subscribers::AttributeNormalizer.call(row[:custom_attributes]) if row[:custom_attributes].present?
 
+          company = upsert_company(row.delete(:company))
+          fields = row.slice(:email, :name, :subscribed, :custom_attributes)
+          fields[:company] = company if company
+
           if row[:external_id].present? && (existing = @team.subscribers.find_by(external_id: row[:external_id]))
-            existing.update!(row.slice(:email, :name, :subscribed, :custom_attributes))
+            existing.update!(fields)
             summary[:updated] += 1
           else
-            @team.subscribers.create!(row.slice(:external_id, :email, :name, :subscribed, :custom_attributes))
+            @team.subscribers.create!(fields.merge(external_id: row[:external_id]))
             summary[:created] += 1
           end
         rescue JSON::ParserError => e
@@ -109,6 +113,32 @@ if defined?(Api::V1::ApplicationController)
     end
 
     private
+
+    # Upsert a Company from a subscriber payload's optional `company` block and
+    # return it (or nil when absent / lacking an external_id). Generic and
+    # source-agnostic: keyed on external_id, scoped to the team, custom
+    # attributes merged (last write wins). Mirrors the Intercom-style pattern
+    # where each contact carries its company inline, so the receiver
+    # find-or-creates and links — no separate company endpoint required.
+    #
+    #   {"external_id": "u_1", "email": "...", "company": {
+    #      "external_id": "t_42", "name": "Acme", "attributes": {"plan": "pro"}}}
+    def upsert_company(payload)
+      return nil if payload.blank?
+      payload = payload.deep_symbolize_keys
+      external_id = payload[:external_id].presence
+      return nil if external_id.nil?
+
+      attrs = payload[:attributes] || payload[:custom_attributes] || {}
+      attrs = ::Subscribers::AttributeNormalizer.call(attrs) if attrs.present?
+
+      company = @team.companies.find_or_initialize_by(external_id: external_id)
+      company.name = payload[:name].presence || company.name.presence || external_id
+      company.custom_attributes = (company.custom_attributes || {}).deep_stringify_keys
+        .merge(attrs.deep_stringify_keys)
+      company.save!
+      company
+    end
 
     module StrongParameters
       # Only allow a list of trusted parameters through.

--- a/test/controllers/api/v1/subscribers_company_sync_test.rb
+++ b/test/controllers/api/v1/subscribers_company_sync_test.rb
@@ -1,0 +1,76 @@
+require "controllers/api/v1/test"
+
+# Company sync at the api/v1 bulk seam.
+#
+# Source apps (Intercom-style) carry each subscriber's company inline as a
+# `company` block on the subscriber payload. The bulk endpoint find-or-creates
+# the Company (keyed on external_id, scoped to the team), merges its custom
+# attributes, and links the subscriber — no separate company endpoint needed.
+#
+# Extends Api::V1::Test (gives @user/@team/access_token) rather than the
+# scaffold-generated SubscribersControllerTest, whose setup depends on a
+# :subscriber factory this app doesn't define.
+class Api::V1::SubscribersCompanySyncTest < Api::V1::Test
+  def post_bulk(*rows)
+    body = rows.map(&:to_json).join("\n") + "\n"
+    post "/api/v1/teams/#{@team.id}/subscribers/bulk",
+      params: body,
+      headers: {"CONTENT_TYPE" => "application/x-ndjson", "Authorization" => "Bearer #{access_token}"}
+  end
+
+  test "bulk upsert creates and links a company from the inline company block" do
+    assert_difference -> { @team.companies.count }, 1 do
+      post_bulk(
+        external_id: "u-100",
+        email: "owner@acme.test",
+        subscribed: true,
+        company: {external_id: "t-100", name: "Acme", attributes: {plan: "pro", tenant_type: "brand", tabs_enabled: "billing,reports"}}
+      )
+    end
+    assert_response :success
+
+    company = @team.subscribers.find_by!(external_id: "u-100").company
+    assert_not_nil company
+    assert_equal "t-100", company.external_id
+    assert_equal "Acme", company.name
+    assert_equal "brand", company.custom_attributes["tenant_type"]
+    assert_equal "pro", company.custom_attributes["plan"]
+    # the generic attribute normalizer applies to company attrs too (CSV -> array)
+    assert_equal ["billing", "reports"], company.custom_attributes["tabs_enabled"]
+  end
+
+  test "bulk upsert reuses an existing company by external_id and merges attributes" do
+    existing = @team.companies.create!(external_id: "t-200", name: "Beta", custom_attributes: {"plan" => "free"})
+
+    assert_no_difference -> { @team.companies.count } do
+      post_bulk(
+        {external_id: "u-201", email: "a@beta.test", subscribed: true,
+         company: {external_id: "t-200", name: "Beta Inc", attributes: {tenant_type: "brand"}}},
+        {external_id: "u-202", email: "b@beta.test", subscribed: true,
+         company: {external_id: "t-200", attributes: {plan: "pro"}}}
+      )
+    end
+    assert_response :success
+
+    existing.reload
+    assert_equal "Beta Inc", existing.name # later name wins; an absent name keeps the prior one
+    assert_equal "brand", existing.custom_attributes["tenant_type"]
+    assert_equal "pro", existing.custom_attributes["plan"] # merged; prior value overwritten, not dropped
+    linked = %w[u-201 u-202].map { |x| @team.subscribers.find_by!(external_id: x).company_id }
+    assert_equal [existing.id], linked.uniq
+  end
+
+  test "bulk upsert with a company block lacking an external_id leaves the subscriber unlinked" do
+    assert_no_difference -> { @team.companies.count } do
+      post_bulk(external_id: "u-250", email: "n@example.test", subscribed: true, company: {name: "No ID"})
+    end
+    assert_response :success
+    assert_nil @team.subscribers.find_by!(external_id: "u-250").company_id
+  end
+
+  test "bulk upsert without a company block leaves the subscriber unlinked (no regression)" do
+    post_bulk(external_id: "u-300", email: "solo@example.test", subscribed: true)
+    assert_response :success
+    assert_nil @team.subscribers.find_by!(external_id: "u-300").company_id
+  end
+end


### PR DESCRIPTION
## What

The `/api/v1/teams/:id/subscribers/bulk` endpoint now upserts a **Company** from an optional `company` block on each subscriber row and links the subscriber to it:

```json
{"external_id":"u_1","email":"a@acme.test","attributes":{...},
 "company":{"external_id":"t_42","name":"Acme","attributes":{"plan":"pro","tenant_type":"brand"}}}
```

- Find-or-create the company by `external_id`, scoped to the team (uses the existing unique `[team_id, external_id]` index).
- Merge `custom_attributes` (last write wins); absent `name` keeps the prior one.
- Company attributes pass through the same `Subscribers::AttributeNormalizer` (so `tabs_enabled: "a,b"` → `["a","b"]` just like subscriber attrs).
- A `company` block with no `external_id`, or no block at all, leaves the subscriber unlinked (no regression).

## Why

Mirrors the Intercom pattern where each contact carries its company inline, so segments can filter on `companies.custom_attributes`. Previously companies were only ever populated by a one-time backfill; the live sync had no way to create/refresh them, so company-keyed segments went stale. This closes that at the ingest seam — **generic, no gem change** (source apps just add the block to their mapper).

## Tests

New `test/controllers/api/v1/subscribers_company_sync_test.rb` — 4 tests / 22 assertions, all green:
- creates + links a company from the inline block (and normalizes its attrs)
- reuses an existing company by `external_id` and merges attributes across rows
- company block lacking `external_id` → unlinked
- no company block → unlinked (regression guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)