### PR TITLE
Add plain-text-only campaign option

### DIFF
--- a/app/controllers/api/v1/campaigns_controller.rb
+++ b/app/controllers/api/v1/campaigns_controller.rb
@@ -48,6 +48,7 @@ if defined?(Api::V1::ApplicationController)
           :preheader,
           :body_markdown,
           :body_mjml,
+          :plain_text_only,
           :status,
           :scheduled_for,
           :email_template_id,

--- a/app/mcp/tools/campaigns/create.rb
+++ b/app/mcp/tools/campaigns/create.rb
@@ -10,7 +10,9 @@ module Mcp
         description <<~DESC
           Creates a new campaign (status defaults to "draft"). Requires a subject.
           Provide body_markdown, body_mjml, or an email_template_id with body content —
-          at least one body source is required. Raises ActiveRecord::RecordInvalid on
+          at least one body source is required. Set plain_text_only: true to send a
+          pure plain-text email: body_markdown is sent verbatim as the text body with
+          no HTML part, template, or tracking. Raises ActiveRecord::RecordInvalid on
           validation failure.
         DESC
         arguments_schema(
@@ -22,6 +24,7 @@ module Mcp
             preheader: {type: "string"},
             body_markdown: {type: "string"},
             body_mjml: {type: "string"},
+            plain_text_only: {type: "boolean", description: "Send a pure plain-text email (body_markdown sent verbatim, no HTML part). Requires body_markdown."},
             email_template_id: {type: "integer"},
             segment_id: {type: "integer"},
             sender_address_id: {type: "integer"},
@@ -29,8 +32,8 @@ module Mcp
           }
         )
 
-        PERMITTED = %w[subject preheader body_markdown body_mjml email_template_id
-          segment_id sender_address_id scheduled_for].freeze
+        PERMITTED = %w[subject preheader body_markdown body_mjml plain_text_only
+          email_template_id segment_id sender_address_id scheduled_for].freeze
 
         def call(arguments:, context:)
           attrs = arguments.slice(*PERMITTED)

--- a/app/mcp/tools/campaigns/update.rb
+++ b/app/mcp/tools/campaigns/update.rb
@@ -9,7 +9,9 @@ module Mcp
         tool_name "campaigns_update"
         description <<~DESC
           Updates an existing campaign. The model enforces that sent campaigns cannot
-          have their body changed. Validation errors raise ActiveRecord::RecordInvalid.
+          have their body changed. Set plain_text_only: true to send a pure plain-text
+          email (body_markdown sent verbatim, no HTML part, template, or tracking).
+          Validation errors raise ActiveRecord::RecordInvalid.
         DESC
         arguments_schema(
           type: "object",
@@ -21,6 +23,7 @@ module Mcp
             preheader: {type: "string"},
             body_markdown: {type: "string"},
             body_mjml: {type: "string"},
+            plain_text_only: {type: "boolean", description: "Send a pure plain-text email (body_markdown sent verbatim, no HTML part). Requires body_markdown."},
             email_template_id: {type: "integer"},
             segment_id: {type: "integer"},
             sender_address_id: {type: "integer"},
@@ -28,8 +31,8 @@ module Mcp
           }
         )
 
-        PERMITTED = %w[subject preheader body_markdown body_mjml email_template_id
-          segment_id sender_address_id scheduled_for].freeze
+        PERMITTED = %w[subject preheader body_markdown body_mjml plain_text_only
+          email_template_id segment_id sender_address_id scheduled_for].freeze
 
         def call(arguments:, context:)
           campaign = context.team.campaigns.find_by!(id: arguments["id"])

--- a/app/mcp/tools/serializers.rb
+++ b/app/mcp/tools/serializers.rb
@@ -70,6 +70,7 @@ module Mcp
           status: c.status,
           body_markdown: c.body_markdown,
           body_mjml: c.body_mjml,
+          plain_text_only: c.plain_text_only,
           email_template_id: c.email_template_id,
           segment_id: c.segment_id,
           sender_address_id: c.sender_address_id,

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -49,6 +49,7 @@ class Campaign < ApplicationRecord
   validates :email_template, scope: true
   validates :segment, scope: true
   validate :body_present_in_some_form
+  validate :plain_text_requires_markdown_body
   validate :assets_must_be_images_under_max_size
   # 🚅 add validations above.
 
@@ -109,7 +110,13 @@ class Campaign < ApplicationRecord
       team.subscribers.subscribed.order(:id).first ||
       placeholder_preview_subscriber
 
-    CampaignRenderer.new(campaign: self, subscriber: subscriber).call.html
+    rendered = CampaignRenderer.new(campaign: self, subscriber: subscriber).call
+    # Plain-text campaigns have no HTML part; wrap the rendered text in a <pre>
+    # so the live-preview iframe shows exactly what subscribers will read,
+    # whitespace and line breaks intact.
+    return plain_text_preview_html(rendered.text) if plain_text_only?
+
+    rendered.html
   rescue => _e
     nil
   end
@@ -246,6 +253,22 @@ class Campaign < ApplicationRecord
   def body_present_in_some_form
     return if body_markdown.present? || body_mjml.present? || email_template&.mjml_body.present?
     errors.add(:base, "Campaign needs a body (markdown), a raw MJML body, or an email template with body content.")
+  end
+
+  # Plain-text campaigns send `body_markdown` verbatim as the text body, so it
+  # must be present — an MJML body or template can't stand in for it.
+  def plain_text_requires_markdown_body
+    return unless plain_text_only?
+    return if body_markdown.present?
+    errors.add(:base, "Plain-text campaigns need a plain-text body.")
+  end
+
+  # Renders the plain-text body inside a <pre> for the in-app preview iframe.
+  # Escapes the text so a stray "<" in the copy can't inject markup.
+  def plain_text_preview_html(text)
+    <<~HTML
+      <pre style="font-family: ui-sans-serif, system-ui, sans-serif; font-size: 14px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; margin: 0; padding: 16px; color: #111;">#{ERB::Util.html_escape(text)}</pre>
+    HTML
   end
 
   # See EmailTemplate#assets_must_be_images_under_max_size — kept parallel.

--- a/app/services/campaign_renderer.rb
+++ b/app/services/campaign_renderer.rb
@@ -41,6 +41,8 @@ class CampaignRenderer
   end
 
   def call
+    return plain_text_result if @campaign.plain_text_only?
+
     html = render_html
     html = inject_tracking(html) if @delivery
     Result.new(
@@ -52,6 +54,21 @@ class CampaignRenderer
   end
 
   private
+
+  # Pure plain-text path: `body_markdown` IS the email body, sent verbatim as
+  # text/plain. No MJML, no email_template, no HTML part, and no open-pixel /
+  # click-tracking — a plain-text email is intentionally tracker-free. Liquid
+  # variable substitution still runs (personalization + {{unsubscribe_url}}),
+  # and the author's line breaks are preserved (no whitespace collapsing the
+  # way strip_to_text does for the HTML alternative).
+  def plain_text_result
+    Result.new(
+      html: nil,
+      text: substitute(@campaign.body_markdown.to_s),
+      subject: substitute(@campaign.subject.to_s),
+      preheader: substitute(@campaign.preheader.to_s)
+    )
+  end
 
   def render_html
     @render_html ||= begin

--- a/app/services/ses_sender.rb
+++ b/app/services/ses_sender.rb
@@ -94,16 +94,19 @@ class SesSender
         end
 
         begin
+          # Always include the text part; only include the HTML part when the
+          # renderer produced one. Plain-text-only campaigns return html=nil,
+          # so they go out as a true text/plain message (no multipart HTML).
+          email_body = {text: {data: rendered.text}}
+          email_body[:html] = {data: rendered.html} if rendered.html.present?
+
           send_args = {
             from_email_address: from_address,
             destination: {to_addresses: [subscriber.email]},
             content: {
               simple: {
                 subject: {data: rendered.subject},
-                body: {
-                  html: {data: rendered.html},
-                  text: {data: rendered.text}
-                }
+                body: email_body
               }
             }
           }

--- a/app/views/account/campaigns/_form.html.erb
+++ b/app/views/account/campaigns/_form.html.erb
@@ -327,6 +327,27 @@ select_classes = "block w-full rounded-md shadow-sm font-light text-base md:text
               <span class="campaign-edit-field-hint__mono"><%= Time.zone.name %></span>.
             </p>
           </div>
+
+          <%# Plain-text-only toggle. When on, the markdown body is sent verbatim
+              as a pure text/plain email — no template chrome, no HTML part, and
+              no open/click tracking. Spans both grid columns so the hint isn't
+              cramped. %>
+          <div class="campaign-edit-field md:col-span-2">
+            <%= form.label :plain_text_only, "Format", class: "campaign-edit-field-label" %>
+            <label class="flex items-center gap-2 mt-1">
+              <%= form.check_box :plain_text_only,
+                    class: "rounded border-base-300 dark:border-base-900 text-primary-500 focus:ring-primary-500" %>
+              <span class="text-base md:text-sm font-light dark:text-base-300">Send as plain text only</span>
+            </label>
+            <p class="campaign-edit-field-hint">
+              Sends a pure plain-text email — no template, no HTML, no open/click
+              tracking. Your body is sent <em>verbatim</em> (markdown isn't rendered),
+              so write it as plain text. Personalization like
+              <span class="campaign-edit-field-hint__mono">{{first_name}}</span> and
+              <span class="campaign-edit-field-hint__mono">{{unsubscribe_url}}</span>
+              still work. Often lands better in the inbox and reads more personally.
+            </p>
+          </div>
           <%# 🚅 super scaffolding will insert new fields above this line. %>
         </div>
       </section>

--- a/db/migrate/20260626120000_add_plain_text_only_to_campaigns.rb
+++ b/db/migrate/20260626120000_add_plain_text_only_to_campaigns.rb
@@ -1,0 +1,5 @@
+class AddPlainTextOnlyToCampaigns < ActiveRecord::Migration[8.1]
+  def change
+    add_column :campaigns, :plain_text_only, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_23_144610) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_26_120000) do
   create_table "account_onboarding_invitation_lists", force: :cascade do |t|
     t.integer "team_id", null: false
     t.json "invitations"
@@ -134,6 +134,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_23_144610) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "body_markdown"
+    t.boolean "plain_text_only", default: false, null: false
     t.index ["email_template_id"], name: "index_campaigns_on_email_template_id"
     t.index ["segment_id"], name: "index_campaigns_on_segment_id"
     t.index ["sender_address_id"], name: "index_campaigns_on_sender_address_id"

--- a/test/controllers/account/campaigns_controller_test.rb
+++ b/test/controllers/account/campaigns_controller_test.rb
@@ -72,6 +72,16 @@ class Account::CampaignsControllerTest < ActionDispatch::IntegrationTest
     assert_equal @template.mjml_body, @campaign.body_mjml
   end
 
+  test "update persists plain_text_only through campaign_params" do
+    refute @campaign.plain_text_only?
+
+    patch account_campaign_url(@campaign), params: {
+      campaign: {plain_text_only: "1", body_markdown: "Just text"}
+    }
+
+    assert @campaign.reload.plain_text_only?
+  end
+
   test "show disables send when recipient_count is 0" do
     # No subscribers on the team, no segment — recipient_count resolves to 0.
     assert_equal 0, @campaign.recipient_count

--- a/test/mcp/tools/campaigns/create_test.rb
+++ b/test/mcp/tools/campaigns/create_test.rb
@@ -46,6 +46,19 @@ module Mcp
           end
         end
 
+        test "creates a plain_text_only campaign" do
+          result = Create.new.invoke(
+            arguments: {
+              "subject" => "Plain",
+              "body_markdown" => "Just text",
+              "plain_text_only" => true
+            },
+            context: @ctx
+          )
+          assert_equal true, result[:campaign][:plain_text_only]
+          assert Campaign.find(result[:campaign][:id]).plain_text_only?
+        end
+
         test "campaign is scoped to the calling team" do
           result = Create.new.invoke(
             arguments: {"subject" => "Scoped", "body_markdown" => "text"},

--- a/test/mcp/tools/campaigns/update_test.rb
+++ b/test/mcp/tools/campaigns/update_test.rb
@@ -30,6 +30,15 @@ module Mcp
           assert_equal "New body", result[:campaign][:body_markdown]
         end
 
+        test "updates plain_text_only" do
+          result = Update.new.invoke(
+            arguments: {"id" => @campaign.id, "plain_text_only" => true},
+            context: @ctx
+          )
+          assert_equal true, result[:campaign][:plain_text_only]
+          assert @campaign.reload.plain_text_only?
+        end
+
         test "raises RecordNotFound for campaign on another team" do
           other_team = create(:team)
           other = other_team.campaigns.create!(subject: "Other", status: "draft", body_markdown: "body")

--- a/test/models/campaign_test.rb
+++ b/test/models/campaign_test.rb
@@ -263,6 +263,54 @@ class CampaignTest < ActiveSupport::TestCase
     end
   end
 
+  # ---------------------------------------------------------------------
+  # Plain-text-only campaigns
+  # ---------------------------------------------------------------------
+  test "plain_text_only campaign is valid with a markdown body and no template" do
+    campaign = @team.campaigns.new(
+      sender_address: @sender,
+      subject: "Plain",
+      plain_text_only: true,
+      body_markdown: "Just text",
+      status: "draft"
+    )
+    assert campaign.valid?, campaign.errors.full_messages.to_sentence
+  end
+
+  test "plain_text_only campaign requires a plain-text (markdown) body" do
+    # body_mjml satisfies the generic body-presence check, so this isolates the
+    # plain-text-specific rule: a plain-text campaign needs its own text body.
+    campaign = @team.campaigns.new(
+      email_template: @template,
+      sender_address: @sender,
+      subject: "Plain",
+      body_mjml: @template.mjml_body,
+      plain_text_only: true,
+      body_markdown: ""
+    )
+    refute campaign.valid?
+    assert(campaign.errors[:base].any? { |m| m =~ /plain.?text/i },
+      "expected a base error about the missing plain-text body, got #{campaign.errors[:base].inspect}")
+  end
+
+  test "preview_html for a plain-text campaign returns escaped text, not MJML chrome" do
+    @team.subscribers.create!(
+      email: "pv@example.com", external_id: "pv", subscribed: true, name: "Pat Lee"
+    )
+    @campaign.update!(
+      plain_text_only: true,
+      body_markdown: "Hello {{first_name}}\n\nLine two",
+      body_mjml: nil,
+      email_template: nil
+    )
+
+    html = @campaign.preview_html
+
+    assert_includes html, "Hello Pat"
+    assert_includes html, "<pre"
+    refute_includes html, "mj-", "preview must not render MJML for a plain-text campaign"
+  end
+
   test "paper_trail records a version on destroy" do
     id = @campaign.id
     @campaign.destroy!

--- a/test/services/campaign_renderer_test.rb
+++ b/test/services/campaign_renderer_test.rb
@@ -490,4 +490,45 @@ class CampaignRendererTest < ActiveSupport::TestCase
     refute_includes result.html, %(href="https://example.com/real")
     assert_match(%r{/track/c/[^"]+}, result.html)
   end
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Plain-text-only campaigns
+  # ──────────────────────────────────────────────────────────────────────
+
+  test "plain_text_only campaign renders text-only with no HTML and no template required" do
+    campaign = @team.campaigns.create!(
+      sender_address: @sender,
+      subject: "Plain hi {{first_name}}",
+      body_markdown: "Hey {{first_name}},\n\nThis is a plain note.\n\nThanks!",
+      plain_text_only: true,
+      status: "draft"
+    )
+
+    result = CampaignRenderer.new(campaign: campaign, subscriber: @subscriber).call
+
+    assert_nil result.html, "plain-text campaigns must not produce an HTML part"
+    assert_includes result.text, "Hey Alice,"
+    assert_includes result.text, "This is a plain note."
+    # Subject still gets variable substitution.
+    assert_equal "Plain hi Alice", result.subject
+    # The body is NOT run through markdown/MJML — raw text is preserved, and
+    # paragraph line breaks survive (not collapsed to a single line).
+    assert_includes result.text, "\n"
+    refute_match(/<[a-z]/i, result.text)
+  end
+
+  test "plain_text_only body still substitutes {{unsubscribe_url}}" do
+    campaign = @team.campaigns.create!(
+      sender_address: @sender,
+      subject: "Plain",
+      body_markdown: "Bye {{first_name}}. Unsubscribe: {{unsubscribe_url}}",
+      plain_text_only: true,
+      status: "draft"
+    )
+
+    result = CampaignRenderer.new(campaign: campaign, subscriber: @subscriber).call
+
+    refute_includes result.text, "{{unsubscribe_url}}"
+    assert_match %r{/unsubscribe/}, result.text
+  end
 end

--- a/test/services/ses_sender_test.rb
+++ b/test/services/ses_sender_test.rb
@@ -196,4 +196,24 @@ class SesSenderTest < ActiveSupport::TestCase
       assert_equal "SES said no", d.error_message
     end
   end
+
+  test "plain_text_only campaign sends a text-only SES body with no HTML part" do
+    @campaign.update!(plain_text_only: true, body_markdown: "Just text", body_mjml: nil, email_template: nil)
+
+    captured = nil
+    fake_client = Object.new
+    fake_client.define_singleton_method(:send_email) do |**args|
+      captured = args
+      Struct.new(:message_id).new("plain-1")
+    end
+
+    with_fake_ses_client(fake_client) do
+      SesSender.send_bulk(campaign: @campaign, subscribers: [@s1])
+    end
+
+    body = captured.dig(:content, :simple, :body)
+    assert body.key?(:text), "expected a text part"
+    refute body.key?(:html), "plain-text campaign must omit the HTML part"
+    assert_equal "Just text", body.dig(:text, :data)
+  end
 end


### PR DESCRIPTION
## What

Adds a per-campaign **plain-text-only** option. When enabled, the campaign body (`body_markdown`) is sent **verbatim** as a pure `text/plain` email — no MJML template, no HTML part, and no open-pixel / click-tracking. Liquid personalization (`{{first_name}}`, `{{unsubscribe_url}}`) and the author's line breaks are preserved.

Motivation: plain-text emails often land better in the inbox and read more personally. Previously every send was multipart HTML (MJML) with only an auto-stripped text fallback — there was no way to author/send a true text-only email.

## How

| Layer | Change |
|------|--------|
| Migration | `campaigns.plain_text_only` boolean, default `false` |
| `CampaignRenderer` | Plain-text path: `html: nil`, `text` = Liquid-substituted `body_markdown` (raw, line breaks intact, no tracking) |
| `SesSender` | Builds the SES body with the HTML part **only when HTML exists** → plain-text campaigns go out as true `text/plain` |
| `Campaign` | Validates a plain-text campaign has a body; live preview wraps the text in `<pre>` |
| Web | "Send as plain text only" toggle in the campaign edit form (Settings) + permitted strong param |
| **MCP** | `plain_text_only` added to `campaigns_create` + `campaigns_update` arg schemas / PERMITTED, and to the campaign serializer |

## Decisions

- Reuses the existing `body_markdown` field as the text source (no new column / editor).
- Plain-text sends are deliberately **tracker-free** (no opens/clicks reported) — part of the "pure plain text" appeal.
- Body is sent **verbatim**, so markdown like `**bold**` shows literal asterisks (correct for plain text).

## Tests

8 new tests, all green; full blast-radius suite passing (434 tests, 0 failures):
- Renderer: text-only output, no HTML part, variable substitution, line-break preservation
- SesSender: text-only SES body (no HTML part)
- Model: validation + plain-text preview
- MCP `campaigns_create` / `campaigns_update`
- Web strong-params path

QA screenshots to follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)