### PR TITLE
Fix MCP OAuth: treat localhost as loopback for any-port redirect matching

### DIFF
--- a/config/initializers/doorkeeper_loopback_redirect_uri.rb
+++ b/config/initializers/doorkeeper_loopback_redirect_uri.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "doorkeeper/oauth/helpers/uri_checker"
+
+# RFC 8252 §7.3 lets an authorization server ignore the port when matching a
+# loopback redirect URI, because such a callback can only reach the user's own
+# machine. Doorkeeper implements this in URIChecker.matches? — but its
+# loopback test is `IPAddr.new(uri.host).loopback?`, which raises for the
+# *hostname* "localhost" (only IP literals parse) and is rescued to false. So
+# the any-port exemption applies to http://127.0.0.1:<port> but NOT to
+# http://localhost:<port>.
+#
+# MCP clients (Claude Code, Cursor) register a loopback callback shaped like
+# http://localhost:<port>/callback and bind a fresh ephemeral port on each
+# launch. Under exact-port matching that breaks re-authorization: the port in
+# the authorize request stops matching the port captured at registration, and
+# Doorkeeper rejects it with "The requested redirect uri is malformed or
+# doesn't match client redirect URI."
+#
+# Treat the "localhost" hostname as loopback too, so the any-port exemption
+# covers it. This only *widens* matching for loopback callbacks — which are
+# safe to allow on any port, since no remote attacker can receive them — and
+# leaves all non-loopback redirect-URI matching unchanged.
+module Doorkeeper
+  module OAuth
+    module Helpers
+      module URIChecker
+        def self.loopback_uri?(uri)
+          return true if uri.host == "localhost"
+
+          IPAddr.new(uri.host).loopback?
+        rescue IPAddr::Error, IPAddr::InvalidAddressError
+          false
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/doorkeeper_loopback_redirect_uri.rb
+++ b/config/initializers/doorkeeper_loopback_redirect_uri.rb
@@ -29,7 +29,9 @@ module Doorkeeper
           return true if uri.host == "localhost"
 
           IPAddr.new(uri.host).loopback?
-        rescue IPAddr::Error, IPAddr::InvalidAddressError
+        rescue IPAddr::Error
+          # IPAddr::InvalidAddressError (raised for non-IP-literal hosts) is a
+          # subclass of IPAddr::Error, so this catches it too.
           false
         end
       end

--- a/test/integration/doorkeeper_loopback_redirect_uri_test.rb
+++ b/test/integration/doorkeeper_loopback_redirect_uri_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Locks in the config/initializers/doorkeeper_loopback_redirect_uri.rb patch:
+# loopback redirect URIs (including the "localhost" hostname) match on any port
+# per RFC 8252 §7.3, while every other redirect-URI match stays exact.
+class DoorkeeperLoopbackRedirectUriTest < ActiveSupport::TestCase
+  URIChecker = Doorkeeper::OAuth::Helpers::URIChecker
+
+  test "localhost is recognized as a loopback host" do
+    assert URIChecker.loopback_uri?(URI.parse("http://localhost:1234/callback"))
+  end
+
+  test "localhost redirect matches regardless of port (the MCP re-auth case)" do
+    assert URIChecker.matches?(
+      "http://localhost:51888/callback",
+      "http://localhost:49222/callback"
+    )
+  end
+
+  test "127.0.0.1 loopback still matches regardless of port" do
+    assert URIChecker.matches?(
+      "http://127.0.0.1:51888/callback",
+      "http://127.0.0.1:49222/callback"
+    )
+  end
+
+  test "non-loopback hosts still require an exact port match" do
+    refute URIChecker.matches?(
+      "https://app.example.com:8443/callback",
+      "https://app.example.com:443/callback"
+    )
+  end
+
+  test "loopback matching does not relax the path" do
+    refute URIChecker.matches?(
+      "http://localhost:5000/evil",
+      "http://localhost:5000/callback"
+    )
+  end
+end


### PR DESCRIPTION
## The actual bug behind the "connection timed out" loop

MCP re-auth (`/mcp`) kept dying with *"connection timed out after 30000ms"*. The real error only surfaced in the browser once auth was cleared and a fresh dynamic registration ran:

> The requested redirect uri is malformed or doesn't match client redirect URI.

That's Doorkeeper rejecting the redirect URI at `/oauth/authorize`. The client then waits for a callback that never comes → 30s timeout. It's **not** the SSE transport or the token TTL.

## Root cause (in Doorkeeper's matcher)

RFC 8252 §7.3 says a server may ignore the **port** when matching a loopback redirect URI. `Doorkeeper::OAuth::Helpers::URIChecker.matches?` implements exactly that:

```ruby
if loopback_uri?(url) && loopback_uri?(client_url)
  url.port = nil
  client_url.port = nil
end
```

…but `loopback_uri?` is `IPAddr.new(uri.host).loopback?`, and `IPAddr.new("localhost")` **raises** (only IP literals parse) → rescued to `false`. So the exemption covers `http://127.0.0.1:<port>` but **not** `http://localhost:<port>`.

Claude Code / Cursor register a loopback callback shaped like `http://localhost:<port>/callback` and bind a **fresh ephemeral port each launch**. Under exact-port matching, every re-auth after the first fails — exactly the "worked once, then stopped" behavior. (Our own `force_ssl_in_redirect_uri` already special-cases `host != "localhost"`, confirming the clients use the `localhost` hostname.)

## Fix

`config/initializers/doorkeeper_loopback_redirect_uri.rb` patches `URIChecker.loopback_uri?` to treat the `localhost` hostname as loopback. This only **widens** matching for loopback callbacks (safe on any port — no remote party can receive a loopback redirect). Non-loopback matching and path matching are unchanged; the added test asserts both boundaries:

- `localhost:51888` ↔ `localhost:49222` → match
- `127.0.0.1` any port → match (unchanged)
- `app.example.com:8443` ↔ `:443` → rejected
- `localhost` different path → rejected

Verified against doorkeeper 5.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
